### PR TITLE
Fixes #37

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,2 +1,6 @@
-/* Invoke ScrollUpBar Plugin */
-$('#topbar').scrollupbar();
+/* Invoke ScrollUpBar Plugin
+   FIXME: Does it even work?
+   1. TypeError: $(...).scrollupbar is not a function
+   2. When loaded, topbar background won't change it color
+*/
+// $('#topbar').scrollupbar();

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,6 +1,9 @@
+jQuery(function($) {
 /* Invoke ScrollUpBar Plugin
    FIXME: Does it even work?
    1. TypeError: $(...).scrollupbar is not a function
    2. When loaded, topbar background won't change it color
 */
 // $('#topbar').scrollupbar();
+
+});

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,9 +1,13 @@
-jQuery(function($) {
-/* Invoke ScrollUpBar Plugin
-   FIXME: Does it even work?
-   1. TypeError: $(...).scrollupbar is not a function
-   2. When loaded, topbar background won't change it color
-*/
-// $('#topbar').scrollupbar();
+/* Invoke ScrollUpBar Plugin */
+$('#topbar').scrollupbar();
 
+$(function(){
+  $(window).scroll(function()
+  {
+    $("#topbar").removeClass("topped").addClass("scrolled");
+    var divTop = $('#topbar').height();
+    if($(this).scrollTop()<=divTop) {
+        $("#topbar").removeClass("scrolled").addClass("topped");
+    }
+  });
 });


### PR DESCRIPTION
As I switched from `scroll-up-bar.js` to `scroll-up-bar.min.js`, the scroll up effect was no more in place (and as I tested, I forgot to clean my cache so it was still working).

I finally found out that the previous `scroll-up-bar.js` wasn't the untouched upstream file but that it has custom code in it:

```js
$('#topbar').scrollupbar();

$(function(){
  $(window).scroll(function()
  {
    $("#topbar").removeClass("topped").addClass("scrolled");
    var divTop = $('#topbar').height();
    if($(this).scrollTop()<=divTop) {
        $("#topbar").removeClass("scrolled").addClass("topped");
    }
  });
});
```

So I put this code in the `index.js` as I'm willing to centralize all the JavaScript function in one file, and fixed what I introduced myself.