### PR TITLE
Automagically add image captions

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -727,6 +727,12 @@ iframe {
 #post a img {
     border: 0 none;
 }
+.post figcaption {
+    font-style: italic;
+    font-size: 85%;
+    color: rgba(0, 0, 0, 0.4);
+    text-align: center;
+}
 blockquote {
     font-style: italic;
     margin: 22px 0;

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -16,3 +16,19 @@ $(function(){
 $(document).ready(function(){
     $("#post").fitVids();
 });
+
+/* Creates Captions from Alt tags */
+$(".post img").each(
+    function() {
+        // Let's put a caption if there is one
+        if ($(this).attr("alt")) {
+            $(this).wrap(
+                '<figure class="image"></figure>'
+            ).after(
+                '<figcaption>' +
+                $(this).attr(
+                    "alt") +
+                '</figcaption>'
+            );
+        }
+    });


### PR DESCRIPTION
Petit bout de code permettant d'intégrer la description de l'image sous celle-ci en utilisant la balise `<figcaption>`, le tout sans avoir besoin d'écrire deux fois le contenu de la description de l'image.

Source: https://blog.kchung.co/adding-image-captions-to-ghost/
![capture d ecran de 2017-08-12 15-01-02](https://user-images.githubusercontent.com/696539/29241537-107cb04c-7f7c-11e7-8962-7f97d02c6181.png)
